### PR TITLE
fix mobile

### DIFF
--- a/src/blog.jl
+++ b/src/blog.jl
@@ -45,7 +45,7 @@ function blog()
         DOM.div(entry, class="$CARD_STYLE blog_entry max-w-prose", style=style)
     end
     body = DOM.div(rss_link, Bonito.Col(site_entries...))
-    return page(Section(body), "Blog")
+    return page(Block(body), "Blog")
 end
 
 export blog


### PR DESCRIPTION
I don't really know what's going on, but any way I try to center the div, makes the div cut off on mobile.
Removing the centering, makes it work just like I'd expect, besides it not being centered anymore on big screens.
I guess, that's better for now, but would be nice to figure this out correctly.